### PR TITLE
Added support for live background updates while showing a dialog box

### DIFF
--- a/components/odroid/odroid_overlay.h
+++ b/components/odroid/odroid_overlay.h
@@ -32,6 +32,8 @@ struct odroid_dialog_choice {
     bool (*update_cb)(odroid_dialog_choice_t *, odroid_dialog_event_t, uint32_t repeat);
 };
 
+typedef void (*repaint_callback_t)();
+
 #define ODROID_DIALOG_CHOICE_LAST {0x0F0F0F0F, "LAST", "LAST", 0xFFFF, NULL}
 
 extern odroid_menu_state_t odroid_menu_state;
@@ -46,11 +48,13 @@ void odroid_overlay_draw_fill_rect(int x, int y, int width, int height, uint16_t
 void odroid_overlay_draw_battery(int x, int y);
 void odroid_overlay_draw_dialog(const char *header, odroid_dialog_choice_t *options, int sel);
 
+int odroid_overlay_dialog_live(const char *header, odroid_dialog_choice_t *options, int selected, repaint_callback_t callback);
 int odroid_overlay_dialog(const char *header, odroid_dialog_choice_t *options, int selected_initial);
 int odroid_overlay_confirm(const char *text, bool yes_selected);
 void odroid_overlay_alert(const char *text);
 bool odroid_overlay_dialog_is_open(void);
 
+int odroid_overlay_settings_menu_live(odroid_dialog_choice_t *extra_options, repaint_callback_t callback);
 int odroid_overlay_settings_menu(odroid_dialog_choice_t *extra_options);
 int odroid_overlay_game_settings_menu(odroid_dialog_choice_t *extra_options);
 int odroid_overlay_game_menu(odroid_dialog_choice_t *extra_options);


### PR DESCRIPTION
This has the benefit of updating both battery and clock status while displaying any of main dialog boxes. This also fixes a gui glitch when the dialog box changes the width while updating or displaying the date/time or when settings->font change.

The API is fully backwards compatible.

This pull request needs https://github.com/sylverb/game-and-watch-retro-go/pull/38